### PR TITLE
Fix title double escape in RSS

### DIFF
--- a/rss.php
+++ b/rss.php
@@ -43,16 +43,16 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
     <?php for($i = 0; $i < $comics_list['rows']; $i++): ?>
     <?php if($i < 25): ?>
     <item>
-      <title><?=htmlspecialchars($comics_list[$i]['title_en'])?></title>
-      <link><?=htmlspecialchars($comics_list[$i]['url'])?></link>
+      <title><?=$comics_list[$i]['title_en']?></title>
+      <link><?=$comics_list[$i]['url']?></link>
       <description><![CDATA[
-        <a href="<?=htmlspecialchars($comics_list[$i]['url'])?>">
+        <a href="<?=$comics_list[$i]['url']?>">
           <img src="<?=$GLOBALS['website_url'].'img/website/pages/rss_top.png'?>" alt="The bad website presents...">
-          <img src="<?=htmlspecialchars($comics_list[$i]['rss_preview'])?>" alt="Comic preview">
+          <img src="<?=$comics_list[$i]['rss_preview']?>" alt="Comic preview">
           <img src="<?=$GLOBALS['website_url'].'img/website/pages/rss_bottom.png'?>" alt="Click here to read the comic">
         </a>
       ]]></description>
-      <pubDate><?=htmlspecialchars($comics_list[$i]['date_rss'])?></pubDate>
+      <pubDate><?=$comics_list[$i]['date_rss']?></pubDate>
     </item>
     <?php endif; ?>
     <?php endfor; ?>


### PR DESCRIPTION
Hello again (: I notice one more issue with RSS, the title in which looks like `Minorities can&#039;t change` in the reader because the generated XML is:

```xml
<title>Minorities can&amp;#039;t change</title>
```

I like the approach of applying `htmlspecialchars` in the view rather than the model, and I also have it that way in production websites. But in The Bad Website there's already a `sanitize_output`/`htmlentities` call in `comics_list`. So the apostrophe is escaped twice and not displayed correctly in the client. Since other parts of the website expect values from the model to come already escaped, I propose not changing the model but removing the `htmlspecialchars` calls from the RSS view instead.